### PR TITLE
Added typing indicator for one-on-one chat 

### DIFF
--- a/chatapp/consumers.py
+++ b/chatapp/consumers.py
@@ -30,18 +30,57 @@ class ChatConsumer(AsyncWebsocketConsumer):
     # Receive message from WebSocket
     async def receive(self, text_data):
         text_data_json = json.loads(text_data)
-        message = text_data_json['message']
-        sender = text_data_json['sender']
+        event_type = text_data_json.get("type") #Check the type of event
 
-        # Send message to room group
-        await self.channel_layer.group_send(
-            self.room_group_name,
-            {
-                'type': 'chat_message',
-                'message': message,
-                'sender': sender
-            }
-        )
+        if event_type == "message":
+            message = text_data_json['message']
+            sender = text_data_json['sender']     
+        
+            # Send message to room group
+            await self.channel_layer.group_send(
+                self.room_group_name,
+                {
+                    'type': 'chat_message',
+                    'message': message,
+                    'sender': sender
+                }
+            )
+        
+        elif event_type == "typing":
+            username = text_data_json["username"]
+
+            await self.channel_layer.group_send(
+                self.room_group_name,
+                {
+                    'type': 'user_typing',
+                    "username": username,
+                }
+            )
+             
+        elif event_type == "stopped_typing":
+            username = text_data_json["username"]
+        
+            await self.channel_layer.group_send(
+                self.room_group_name,
+                {
+                    'type': 'user_stopped_typing',
+                    'username': username,
+                }
+            )        
+
+    #Outgoing Typing indicator functions
+
+    async def user_typing(self, event):
+        await self.send(text_data = json.dumps({
+            'type':'typing',
+            'username': event['username'],
+        }))
+
+    async def user_stopped_typing(self, event):
+        await self.send(text_data = json.dumps({
+            'type':'stopped_typing',
+            'username': event['username'],
+        }))
 
     # Receive message from room group
     async def chat_message(self, event):

--- a/chatapp/templates/chatapp/chat.html
+++ b/chatapp/templates/chatapp/chat.html
@@ -5,6 +5,9 @@
 <div class="max-w-4xl mx-auto bg-white rounded-lg shadow-md">
     <div class="border-b p-4">
         <h2 class="text-xl font-semibold">Chat with {{ other_user.username }}</h2>
+        <div id="typing-indicator" class="px-4 py-2 text-sm text-gray-500 hidden">
+            <span id="typing-username"></span> is typing...
+        </div>
     </div>
     
     <div id="chat-messages" class="h-96 overflow-y-auto p-4 space-y-4">


### PR DESCRIPTION
1) Added a typing indicator which is displayed under Chat room "User is typing" when user starts typing.

2) An event listener is added to the input field which detects when the user starts and stops typing and this is sent to the WebSocket which broadcasts this to the chat participant. The frontend listens for such events and updates the UI accordingly.

3) Note that currently this only works for 1-on-1 chats. Group chat support is not implemented.